### PR TITLE
Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ $ onyx register
 $ onyx create <project> --field <name> <value> --field <name> <value> ...
 ```
 ```python
-from onyx import OnyxSession
+from onyx import OnyxClient
 
-with OnyxSession() as client:
+with OnyxClient() as client:
     # Create a single record
     response = client.create(
         "project",
@@ -90,9 +90,9 @@ $ onyx create <project> --csv <csv>
 $ onyx create <project> --tsv <tsv>
 ```
 ```python
-from onyx import OnyxSession
+from onyx import OnyxClient
 
-with OnyxSession() as client:
+with OnyxClient() as client:
     # Create from a csv of records, by providing the path
     responses = client.csv_create(
         "project",
@@ -125,9 +125,9 @@ with OnyxSession() as client:
 $ onyx get <project> <cid>
 ```
 ```python
-from onyx import OnyxSession 
+from onyx import OnyxClient 
 
-with OnyxSession() as client:
+with OnyxClient() as client:
     response = client.get("project", "cid")
 
     # Print the response
@@ -139,10 +139,10 @@ with OnyxSession() as client:
 $ onyx filter <project> --field <name> <value> --field <name> <value> ...
 ```
 ```python
-from onyx import OnyxSession
+from onyx import OnyxClient
 
 # Retrieve all records matching ALL of the field requirements
-with OnyxSession() as client:
+with OnyxClient() as client:
     responses = client.filter(
         "project",
         fields={
@@ -161,9 +161,9 @@ with OnyxSession() as client:
 
 #### The `query` endpoint 
 ```python
-from onyx import OnyxSession, F
+from onyx import OnyxClient, F
 
-with OnyxSession() as client:
+with OnyxClient() as client:
     # The python bitwise operators can be used in a query.
     # These are:
     # AND: &
@@ -229,9 +229,9 @@ Most of these lookups (excluding `ne`, which is a custom lookup meaning `not equ
 $ onyx update <project> <cid> --field <name> <value> --field <name> <value> ...
 ```
 ```python
-from onyx import OnyxSession
+from onyx import OnyxClient
 
-with OnyxSession() as client:
+with OnyxClient() as client:
     response = client.update(
         "project",
         "cid",
@@ -252,9 +252,9 @@ $ onyx update <project> --csv <csv>
 $ onyx update <project> --tsv <tsv>
 ```
 ```python
-from onyx import OnyxSession
+from onyx import OnyxClient
 
-with OnyxSession() as client:
+with OnyxClient() as client:
     # Update from a csv of records
     responses = client.csv_update(
         "project",
@@ -273,9 +273,9 @@ with OnyxSession() as client:
 $ onyx suppress <project> <cid>
 ```
 ```python
-from onyx import OnyxSession 
+from onyx import OnyxClient 
 
-with OnyxSession() as client:
+with OnyxClient() as client:
     response = client.suppress("project", "cid")
     print(response)
 ```
@@ -286,9 +286,9 @@ $ onyx suppress <project> --csv <csv>
 $ onyx suppress <project> --tsv <tsv>
 ```
 ```python
-from onyx import OnyxSession
+from onyx import OnyxClient
 
-with OnyxSession() as client:
+with OnyxClient() as client:
     # Suppress from a csv of records
     responses = client.csv_suppress(
         "project",
@@ -307,9 +307,9 @@ with OnyxSession() as client:
 $ onyx delete <project> <cid>
 ```
 ```python
-from onyx import OnyxSession 
+from onyx import OnyxClient 
 
-with OnyxSession() as client:
+with OnyxClient() as client:
     response = client.delete("project", "cid")
     print(response)
 ```
@@ -320,9 +320,9 @@ $ onyx delete <project> --csv <csv>
 $ onyx delete <project> --tsv <tsv>
 ```
 ```python
-from onyx import OnyxSession
+from onyx import OnyxClient
 
-with OnyxSession() as client:
+with OnyxClient() as client:
     # Delete from a csv of records
     responses = client.csv_delete(
         "project",

--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ $ onyx register
 $ onyx create <project> --field <name> <value> --field <name> <value> ...
 ```
 ```python
-from onyx import Session
+from onyx import OnyxSession
 
-with Session() as client:
+with OnyxSession() as client:
     # Create a single record
     response = client.create(
         "project",
@@ -90,9 +90,9 @@ $ onyx create <project> --csv <csv>
 $ onyx create <project> --tsv <tsv>
 ```
 ```python
-from onyx import Session
+from onyx import OnyxSession
 
-with Session() as client:
+with OnyxSession() as client:
     # Create from a csv of records, by providing the path
     responses = client.csv_create(
         "project",
@@ -125,9 +125,9 @@ with Session() as client:
 $ onyx get <project> <cid>
 ```
 ```python
-from onyx import Session 
+from onyx import OnyxSession 
 
-with Session() as client:
+with OnyxSession() as client:
     response = client.get("project", "cid")
 
     # Print the response
@@ -139,10 +139,10 @@ with Session() as client:
 $ onyx filter <project> --field <name> <value> --field <name> <value> ...
 ```
 ```python
-from onyx import Session
+from onyx import OnyxSession
 
 # Retrieve all records matching ALL of the field requirements
-with Session() as client:
+with OnyxSession() as client:
     responses = client.filter(
         "project",
         fields={
@@ -161,9 +161,9 @@ with Session() as client:
 
 #### The `query` endpoint 
 ```python
-from onyx import Session, F
+from onyx import OnyxSession, F
 
-with Session() as client:
+with OnyxSession() as client:
     # The python bitwise operators can be used in a query.
     # These are:
     # AND: &
@@ -229,9 +229,9 @@ Most of these lookups (excluding `ne`, which is a custom lookup meaning `not equ
 $ onyx update <project> <cid> --field <name> <value> --field <name> <value> ...
 ```
 ```python
-from onyx import Session
+from onyx import OnyxSession
 
-with Session() as client:
+with OnyxSession() as client:
     response = client.update(
         "project",
         "cid",
@@ -252,9 +252,9 @@ $ onyx update <project> --csv <csv>
 $ onyx update <project> --tsv <tsv>
 ```
 ```python
-from onyx import Session
+from onyx import OnyxSession
 
-with Session() as client:
+with OnyxSession() as client:
     # Update from a csv of records
     responses = client.csv_update(
         "project",
@@ -273,9 +273,9 @@ with Session() as client:
 $ onyx suppress <project> <cid>
 ```
 ```python
-from onyx import Session 
+from onyx import OnyxSession 
 
-with Session() as client:
+with OnyxSession() as client:
     response = client.suppress("project", "cid")
     print(response)
 ```
@@ -286,9 +286,9 @@ $ onyx suppress <project> --csv <csv>
 $ onyx suppress <project> --tsv <tsv>
 ```
 ```python
-from onyx import Session
+from onyx import OnyxSession
 
-with Session() as client:
+with OnyxSession() as client:
     # Suppress from a csv of records
     responses = client.csv_suppress(
         "project",
@@ -307,9 +307,9 @@ with Session() as client:
 $ onyx delete <project> <cid>
 ```
 ```python
-from onyx import Session 
+from onyx import OnyxSession 
 
-with Session() as client:
+with OnyxSession() as client:
     response = client.delete("project", "cid")
     print(response)
 ```
@@ -320,9 +320,9 @@ $ onyx delete <project> --csv <csv>
 $ onyx delete <project> --tsv <tsv>
 ```
 ```python
-from onyx import Session
+from onyx import OnyxSession
 
-with Session() as client:
+with OnyxSession() as client:
     # Delete from a csv of records
     responses = client.csv_delete(
         "project",

--- a/onyx/__init__.py
+++ b/onyx/__init__.py
@@ -1,4 +1,4 @@
 from .config import OnyxConfig
 from .api import OnyxClient
-from .utils import print_response, execute_uploads, iterate
+from .utils import print_response, execute_uploads, iterate_records
 from django_query_tools.client import F

--- a/onyx/__init__.py
+++ b/onyx/__init__.py
@@ -1,4 +1,4 @@
-from .config import Config
-from .api import Client, Session
+from .config import OnyxConfig
+from .api import OnyxClient, OnyxSession
 from .utils import print_response, execute_uploads, iterate
 from django_query_tools.client import F

--- a/onyx/__init__.py
+++ b/onyx/__init__.py
@@ -1,4 +1,4 @@
 from .config import OnyxConfig
-from .api import OnyxClient, OnyxSession
+from .api import OnyxClient
 from .utils import print_response, execute_uploads, iterate
 from django_query_tools.client import F

--- a/onyx/api.py
+++ b/onyx/api.py
@@ -6,96 +6,70 @@ import requests
 import concurrent.futures
 from django_query_tools.client import F
 from . import utils, settings
-from .config import Config
+from .config import OnyxConfig
 
 
-class Client:
-    def __init__(self, config):
-        """
-        Initialise the client with a given config.
-        """
-        self.config = config
-        self.endpoints = {
-            # accounts
-            "register": os.path.join(self.config.domain, "accounts/register/"),
-            "login": os.path.join(self.config.domain, "accounts/login/"),
-            "logout": os.path.join(self.config.domain, "accounts/logout/"),
-            "logoutall": os.path.join(self.config.domain, "accounts/logoutall/"),
-            "site_approve": lambda x: os.path.join(
-                self.config.domain, f"accounts/site/approve/{x}/"
-            ),
-            "site_waiting": os.path.join(self.config.domain, "accounts/site/waiting/"),
-            "site_users": os.path.join(self.config.domain, "accounts/site/users/"),
-            "admin_approve": lambda x: os.path.join(
-                self.config.domain, f"accounts/admin/approve/{x}/"
-            ),
-            "admin_waiting": os.path.join(
-                self.config.domain, "accounts/admin/waiting/"
-            ),
-            "admin_users": os.path.join(self.config.domain, "accounts/admin/users/"),
-            # data
-            "create": lambda x: os.path.join(self.config.domain, f"data/create/{x}/"),
-            "testcreate": lambda x: os.path.join(
-                self.config.domain, f"data/testcreate/{x}/"
-            ),
-            "get": lambda x, y: os.path.join(self.config.domain, f"data/get/{x}/{y}/"),
-            "filter": lambda x: os.path.join(self.config.domain, f"data/filter/{x}/"),
-            "query": lambda x: os.path.join(self.config.domain, f"data/query/{x}/"),
-            "update": lambda x, y: os.path.join(
-                self.config.domain, f"data/update/{x}/{y}/"
-            ),
-            "testupdate": lambda x, y: os.path.join(
-                self.config.domain, f"data/testupdate/{x}/{y}/"
-            ),
-            "suppress": lambda x, y: os.path.join(
-                self.config.domain, f"data/suppress/{x}/{y}/"
-            ),
-            "testsuppress": lambda x, y: os.path.join(
-                self.config.domain, f"data/testsuppress/{x}/{y}/"
-            ),
-            "delete": lambda x, y: os.path.join(
-                self.config.domain, f"data/delete/{x}/{y}/"
-            ),
-            "testdelete": lambda x, y: os.path.join(
-                self.config.domain, f"data/testdelete/{x}/{y}/"
-            ),
-            "choices": lambda x, y: os.path.join(
-                self.config.domain, f"data/choices/{x}/{y}/"
-            ),
-        }
+class OnyxClient:
+    ENDPOINTS = {
+        # ACCOUNTS
+        "register": lambda domain: os.path.join(domain, "accounts/register/"),
+        "login": lambda domain: os.path.join(domain, "accounts/login/"),
+        "logout": lambda domain: os.path.join(domain, "accounts/logout/"),
+        "logoutall": lambda domain: os.path.join(domain, "accounts/logoutall/"),
+        "site_approve": lambda domain, username: os.path.join(
+            domain, f"accounts/site/approve/{username}/"
+        ),
+        "site_waiting": lambda domain: os.path.join(domain, "accounts/site/waiting/"),
+        "site_users": lambda domain: os.path.join(domain, "accounts/site/users/"),
+        "admin_approve": lambda domain, username: os.path.join(
+            domain, f"accounts/admin/approve/{username}/"
+        ),
+        "admin_waiting": lambda domain: os.path.join(domain, "accounts/admin/waiting/"),
+        "admin_users": lambda domain: os.path.join(domain, "accounts/admin/users/"),
+        # DATA
+        "create": lambda domain, project: os.path.join(
+            domain, f"data/create/{project}/"
+        ),
+        "testcreate": lambda domain, project: os.path.join(
+            domain, f"data/testcreate/{project}/"
+        ),
+        "get": lambda domain, project, cid: os.path.join(
+            domain, f"data/get/{project}/{cid}/"
+        ),
+        "filter": lambda domain, project: os.path.join(
+            domain, f"data/filter/{project}/"
+        ),
+        "query": lambda domain, project: os.path.join(domain, f"data/query/{project}/"),
+        "update": lambda domain, project, cid: os.path.join(
+            domain, f"data/update/{project}/{cid}/"
+        ),
+        "testupdate": lambda domain, project, cid: os.path.join(
+            domain, f"data/testupdate/{project}/{cid}/"
+        ),
+        "suppress": lambda domain, project, cid: os.path.join(
+            domain, f"data/suppress/{project}/{cid}/"
+        ),
+        "testsuppress": lambda domain, project, cid: os.path.join(
+            domain, f"data/testsuppress/{project}/{cid}/"
+        ),
+        "delete": lambda domain, project, cid: os.path.join(
+            domain, f"data/delete/{project}/{cid}/"
+        ),
+        "testdelete": lambda domain, project, cid: os.path.join(
+            domain, f"data/testdelete/{project}/{cid}/"
+        ),
+        "choices": lambda domain, project, cid: os.path.join(
+            domain, f"data/choices/{project}/{cid}/"
+        ),
+    }
 
-    def request(self, method, **kwargs):
-        """
-        Carry out a request while handling token authorisation.
-        """
-        kwargs.setdefault("headers", {}).update(
-            {"Authorization": f"Token {self.token}"}
-        )
-        method_response = method(**kwargs)
-
-        if method_response.status_code == 401 and self.env_password:
-            login_response = requests.post(
-                self.endpoints["login"],
-                auth=(self.username, self.get_password()),
-            )
-
-            if login_response.ok:
-                self.token = login_response.json()["data"]["token"]
-                self.expiry = login_response.json()["data"]["expiry"]
-                self.config.write_token(self.username, self.token, self.expiry)
-
-                return self.request(method, **kwargs)
-
-            login_response.raise_for_status()
-
-        return method_response
-
-    def register(self, first_name, last_name, email, site, password):
+    @classmethod
+    def register(cls, config, first_name, last_name, email, site, password):
         """
         Create a new user.
         """
         response = requests.post(
-            self.endpoints["register"],
+            cls.ENDPOINTS["register"](config.domain),
             json={
                 "first_name": first_name,
                 "last_name": last_name,
@@ -106,20 +80,28 @@ class Client:
         )
         return response
 
-    def continue_session(self, username=None, env_password=False):
+    def __init__(self, config=None, username=None, env_password=False):
+        """
+        Initialise the client.
+        """
+        if config:
+            self.config = config
+        else:
+            self.config = OnyxConfig()
+
+        # Assign username/env_password flag to the client
         if username is None:
-            # Attempt to use default_user if no username was provided
+            # If no username was provided, use the default user
             if self.config.default_user is None:
                 raise Exception(
                     "No username was provided and there is no default_user in the config. Either provide a username or set a default_user"
                 )
-            else:
-                # The default_user must be in the config
-                if self.config.default_user not in self.config.users:
-                    raise Exception(
-                        f"default_user '{self.config.default_user}' is not in the users list for the config"
-                    )
-                username = self.config.default_user
+            if self.config.default_user not in self.config.users:
+                raise Exception(
+                    f"default_user '{self.config.default_user}' is not in the users list for the config"
+                )
+
+            username = self.config.default_user
         else:
             # Username is case-insensitive
             username = username.lower()
@@ -144,8 +126,6 @@ class Client:
             self.token = token_data.get("token")
             self.expiry = token_data.get("expiry")
 
-        return username
-
     def get_password(self):
         if self.env_password:
             # If the password is meant to be an env var, grab it.
@@ -162,27 +142,50 @@ class Client:
             password = utils.get_input("password", password=True)
         return password
 
-    def login(self, username=None, env_password=False):
+    def request(self, method, **kwargs):
+        """
+        Carry out a request while handling token authorisation.
+        """
+        kwargs.setdefault("headers", {}).update(
+            {"Authorization": f"Token {self.token}"}
+        )
+        method_response = requests.request(method, **kwargs)
+
+        if method_response.status_code == 401 and self.env_password:
+            login_response = requests.post(
+                self.ENDPOINTS["login"](self.config.domain),
+                auth=(self.username, self.get_password()),
+            )
+
+            if login_response.ok:
+                self.token = login_response.json()["data"]["token"]
+                self.expiry = login_response.json()["data"]["expiry"]
+
+                # TODO: Is there a potential infinite loop here
+                return self.request(method, **kwargs)
+
+            login_response.raise_for_status()
+
+        return method_response
+
+    @utils.session_required
+    def login(self):
         """
         Log in as a particular user, get a new token and store the token in the client.
 
         If no user is provided, the `default_user` in the config is used.
         """
-
-        # Assigns username/env_password flag to the client
-        self.continue_session(username, env_password=env_password)
-
         # Get the password
         password = self.get_password()
 
         # Log in
         response = requests.post(
-            self.endpoints["login"], auth=(self.username, password)
+            auth=(self.username, password),
+            url=self.ENDPOINTS["login"](self.config.domain),
         )
         if response.ok:
             self.token = response.json()["data"]["token"]
             self.expiry = response.json()["data"]["expiry"]
-            self.config.write_token(self.username, self.token, self.expiry)
 
         return response
 
@@ -192,13 +195,12 @@ class Client:
         Log out the user in this client.
         """
         response = self.request(
-            method=requests.post,
-            url=self.endpoints["logout"],
+            method="post",
+            url=self.ENDPOINTS["logout"](self.config.domain),
         )
         if response.ok:
             self.token = None
             self.expiry = None
-            self.config.write_token(self.username, self.token, self.expiry)
 
         return response
 
@@ -208,13 +210,12 @@ class Client:
         Log out the user in all clients.
         """
         response = self.request(
-            method=requests.post,
-            url=self.endpoints["logoutall"],
+            method="post",
+            url=self.ENDPOINTS["logoutall"](self.config.domain),
         )
         if response.ok:
             self.token = None
             self.expiry = None
-            self.config.write_token(self.username, self.token, self.expiry)
 
         return response
 
@@ -224,8 +225,8 @@ class Client:
         Site-approve another user.
         """
         response = self.request(
-            method=requests.patch,
-            url=self.endpoints["site_approve"](username),
+            method="patch",
+            url=self.ENDPOINTS["site_approve"](self.config.domain, username),
         )
         return response
 
@@ -235,8 +236,8 @@ class Client:
         List users waiting for site approval.
         """
         response = self.request(
-            method=requests.get,
-            url=self.endpoints["site_waiting"],
+            method="get",
+            url=self.ENDPOINTS["site_waiting"](self.config.domain),
         )
         return response
 
@@ -246,8 +247,8 @@ class Client:
         Get the current users within the site of the requesting user.
         """
         response = self.request(
-            method=requests.get,
-            url=self.endpoints["site_users"],
+            method="get",
+            url=self.ENDPOINTS["site_users"](self.config.domain),
         )
         return response
 
@@ -257,8 +258,8 @@ class Client:
         Admin-approve another user.
         """
         response = self.request(
-            method=requests.patch,
-            url=self.endpoints["admin_approve"](username),
+            method="patch",
+            url=self.ENDPOINTS["admin_approve"](self.config.domain, username),
         )
         return response
 
@@ -268,8 +269,8 @@ class Client:
         List users waiting for admin approval.
         """
         response = self.request(
-            method=requests.get,
-            url=self.endpoints["admin_waiting"],
+            method="get",
+            url=self.ENDPOINTS["admin_waiting"](self.config.domain),
         )
         return response
 
@@ -279,8 +280,8 @@ class Client:
         List all users.
         """
         response = self.request(
-            method=requests.get,
-            url=self.endpoints["admin_users"],
+            method="get",
+            url=self.ENDPOINTS["admin_users"](self.config.domain),
         )
         return response
 
@@ -295,8 +296,8 @@ class Client:
             endpoint = "create"
 
         response = self.request(
-            method=requests.post,
-            url=self.endpoints[endpoint](project),
+            method="post",
+            url=self.ENDPOINTS[endpoint](self.config.domain, project),
             json=fields,
         )
         return response
@@ -344,8 +345,8 @@ class Client:
 
             if record:
                 response = self.request(
-                    method=requests.post,
-                    url=self.endpoints[endpoint](project),
+                    method="post",
+                    url=self.ENDPOINTS[endpoint](self.config.domain, project),
                     json=record,
                 )
                 yield response
@@ -357,7 +358,9 @@ class Client:
                             executor.submit(
                                 self.request,
                                 requests.post,
-                                url=self.endpoints[endpoint](project),
+                                url=self.ENDPOINTS[endpoint](
+                                    self.config.domain, project
+                                ),
                                 json=record,
                             )
                             for record in reader
@@ -368,8 +371,8 @@ class Client:
                 else:
                     for record in reader:
                         response = self.request(
-                            method=requests.post,
-                            url=self.endpoints[endpoint](project),
+                            method="post",
+                            url=self.ENDPOINTS[endpoint](self.config.domain, project),
                             json=record,
                         )
                         yield response
@@ -384,8 +387,8 @@ class Client:
         Get a record from the database.
         """
         response = self.request(
-            method=requests.get,
-            url=self.endpoints["get"](project, cid),
+            method="get",
+            url=self.ENDPOINTS["get"](self.config.domain, project, cid),
             params={"scope": scope},
         )
         return response
@@ -401,11 +404,11 @@ class Client:
         if scope:
             fields["scope"] = scope
 
-        _next = self.endpoints["filter"](project)
+        _next = self.ENDPOINTS["filter"](self.config.domain, project)
 
         while _next is not None:
             response = self.request(
-                method=requests.get,
+                method="get",
                 url=_next,
                 params=fields,
             )
@@ -429,11 +432,11 @@ class Client:
                 query = query.query
 
         fields = {"scope": scope}
-        _next = self.endpoints["query"](project)
+        _next = self.ENDPOINTS["query"](self.config.domain, project)
 
         while _next is not None:
             response = self.request(
-                method=requests.post,
+                method="post",
                 url=_next,
                 json=query,
                 params=fields,
@@ -457,8 +460,8 @@ class Client:
             endpoint = "update"
 
         response = self.request(
-            method=requests.patch,
-            url=self.endpoints[endpoint](project, cid),
+            method="patch",
+            url=self.ENDPOINTS[endpoint](self.config.domain, project, cid),
             json=fields,
         )
         return response
@@ -489,8 +492,8 @@ class Client:
                     raise KeyError("cid column must be provided")
 
                 response = self.request(
-                    method=requests.patch,
-                    url=self.endpoints[endpoint](project, cid),
+                    method="patch",
+                    url=self.ENDPOINTS[endpoint](self.config.domain, project, cid),
                     json=record,
                 )
                 yield response
@@ -509,8 +512,8 @@ class Client:
             endpoint = "suppress"
 
         response = self.request(
-            method=requests.delete,
-            url=self.endpoints[endpoint](project, cid),
+            method="delete",
+            url=self.ENDPOINTS[endpoint](self.config.domain, project, cid),
         )
         return response
 
@@ -540,8 +543,8 @@ class Client:
                     raise KeyError("cid column must be provided")
 
                 response = self.request(
-                    method=requests.delete,
-                    url=self.endpoints[endpoint](project, cid),
+                    method="delete",
+                    url=self.ENDPOINTS[endpoint](self.config.domain, project, cid),
                 )
                 yield response
         finally:
@@ -559,8 +562,8 @@ class Client:
             endpoint = "delete"
 
         response = self.request(
-            method=requests.delete,
-            url=self.endpoints[endpoint](project, cid),
+            method="delete",
+            url=self.ENDPOINTS[endpoint](self.config.domain, project, cid),
         )
         return response
 
@@ -590,8 +593,8 @@ class Client:
                     raise KeyError("cid column must be provided")
 
                 response = self.request(
-                    method=requests.delete,
-                    url=self.endpoints[endpoint](project, cid),
+                    method="delete",
+                    url=self.ENDPOINTS[endpoint](self.config.domain, project, cid),
                 )
                 yield response
         finally:
@@ -604,35 +607,37 @@ class Client:
         View choices for a field.
         """
         response = self.request(
-            method=requests.get,
-            url=self.endpoints["choices"](project, field),
+            method="get",
+            url=self.ENDPOINTS["choices"](self.config.domain, project, field),
         )
         return response
 
 
-class Session:
-    def __init__(self, username=None, env_password=False, login=False, logout=False):
-        self.config = Config()
-        self.client = Client(self.config)
-        self.username = username
-        self.env_password = env_password
-        self.login = login
-        self.logout = logout
+class OnyxSession:
+    def __init__(
+        self,
+        username=None,
+        env_password=False,
+        config_dir=None,
+        persist=True,
+    ):
+        self.session = requests.Session()  # TODO
+        self.config = OnyxConfig(dir_path=config_dir)
+        self.client = OnyxClient(
+            self.config,
+            username=username,
+            env_password=env_password,
+        )
+        self.persist = persist
 
     def __enter__(self):
-        if self.login:
-            response = self.client.login(
-                username=self.username,
-                env_password=self.env_password,
-            )
-            response.raise_for_status()
-        else:
-            self.client.continue_session(
-                username=self.username,
-                env_password=self.env_password,
-            )
+        if not self.persist:
+            self.client.login().raise_for_status()
+
         return self.client
 
     def __exit__(self, type, value, traceback):
-        if self.logout:
+        self.session.close()
+
+        if not self.persist:
             self.client.logout()

--- a/onyx/api.py
+++ b/onyx/api.py
@@ -397,24 +397,27 @@ class OnyxClient:
                 csv_file.close()
 
     @utils.session_required
-    def get(self, project, cid, scope=None):
+    def get(self, project, cid, exclude=None, scope=None):
         """
         Get a record from the database.
         """
         response = self.request(
             method="get",
             url=self.ENDPOINTS["get"](self.config.domain, project, cid),
-            params={"scope": scope},
+            params={"exclude": exclude, "scope": scope},
         )
         return response
 
     @utils.session_required
-    def filter(self, project, fields=None, scope=None):
+    def filter(self, project, fields=None, exclude=None, scope=None):
         """
         Filter records from the database.
         """
         if fields is None:
             fields = {}
+
+        if exclude:
+            fields["exclude"] = exclude
 
         if scope:
             fields["scope"] = scope

--- a/onyx/api.py
+++ b/onyx/api.py
@@ -94,11 +94,11 @@ class OnyxClient:
             # If no username was provided, use the default user
             if self.config.default_user is None:
                 raise Exception(
-                    "No username was provided and there is no default_user in the config. Either provide a username or set a default_user"
+                    "No username was provided and there is no default_user in the config. Either provide a username or set a default_user."
                 )
             if self.config.default_user not in self.config.users:
                 raise Exception(
-                    f"default_user '{self.config.default_user}' is not in the users list for the config"
+                    f"default_user '{self.config.default_user}' is not in the users list for the config."
                 )
 
             username = self.config.default_user
@@ -109,7 +109,7 @@ class OnyxClient:
             # The provided user must be in the config
             if username not in self.config.users:
                 raise KeyError(
-                    f"User '{username}' is not in the config. Add them using the add-user config command"
+                    f"User '{username}' is not in the config. Add them using the add-user config command."
                 )
 
         # Assign username to the client
@@ -119,10 +119,16 @@ class OnyxClient:
         self.env_password = env_password
 
         # Open the token file for the user and assign the current token, and its expiry, to the client
-        with open(
-            os.path.join(self.config.dir_path, self.config.users[username]["token"])
-        ) as token_file:
-            token_data = json.load(token_file)
+        token_path = os.path.join(
+            self.config.dir_path, self.config.users[username]["token"]
+        )
+        with open(token_path) as token_file:
+            try:
+                token_data = json.load(token_file)
+            except json.decoder.JSONDecodeError as e:
+                raise Exception(
+                    f"Failed to parse the tokens file: {token_path}\nSomething is wrong with your tokens file. \nTo fix this, either re-add the user to the config via the CLI, or correct the file manually."
+                ) from e
             self.token = token_data.get("token")
             self.expiry = token_data.get("expiry")
 
@@ -336,10 +342,10 @@ class OnyxClient:
             endpoint = "create"
 
         if multithreaded and not self.env_password:
-            raise Exception("Multithreaded upload requires env_password = True")
+            raise Exception("Multithreaded upload requires env_password = True.")
 
         if csv_path and csv_file:
-            raise Exception("Cannot provide both csv_path and csv_file")
+            raise Exception("Cannot provide both csv_path and csv_file.")
 
         if csv_path:
             if csv_path == "-":
@@ -348,7 +354,7 @@ class OnyxClient:
                 csv_file = open(csv_path)
         else:
             if not csv_file:
-                raise Exception("Must provide either csv_path or csv_file")
+                raise Exception("Must provide either csv_path or csv_file.")
 
         try:
             if delimiter is None:
@@ -445,7 +451,7 @@ class OnyxClient:
         """
         if query:
             if not isinstance(query, F):
-                raise Exception("Query must be an F object")
+                raise Exception("Query must be an F object.")
             else:
                 query = query.query
 
@@ -507,7 +513,7 @@ class OnyxClient:
             for record in reader:
                 cid = record.pop("cid", None)
                 if cid is None:
-                    raise KeyError("cid column must be provided")
+                    raise KeyError("A 'cid' column must be provided.")
 
                 response = self.request(
                     method="patch",
@@ -558,7 +564,7 @@ class OnyxClient:
             for record in reader:
                 cid = record.get("cid")
                 if cid is None:
-                    raise KeyError("cid column must be provided")
+                    raise KeyError("A 'cid' column must be provided.")
 
                 response = self.request(
                     method="delete",
@@ -608,7 +614,7 @@ class OnyxClient:
             for record in reader:
                 cid = record.get("cid")
                 if cid is None:
-                    raise KeyError("cid column must be provided")
+                    raise KeyError("A 'cid' column must be provided.")
 
                 response = self.request(
                     method="delete",

--- a/onyx/api.py
+++ b/onyx/api.py
@@ -439,7 +439,7 @@ class OnyxClient:
                 _next = None
 
     @utils.session_required
-    def query(self, project, query=None, scope=None):
+    def query(self, project, query=None, exclude=None, scope=None):
         """
         Get records from the database.
         """
@@ -449,7 +449,7 @@ class OnyxClient:
             else:
                 query = query.query
 
-        fields = {"scope": scope}
+        fields = {"exclude": exclude, "scope": scope}
         _next = self.ENDPOINTS["query"](self.config.domain, project)
 
         while _next is not None:

--- a/onyx/cli.py
+++ b/onyx/cli.py
@@ -676,7 +676,7 @@ def run(args):
 
     elif args.command == "get":
         get_commands = GetCommands(args.user, args.envpass)
-        get_commands.get(args.project, args.cid, scope=args.scope)
+        get_commands.get(args.project, args.cid, exclude=args.exclude, scope=args.scope)
 
     elif args.command == "filter":
         filter_commands = FilterCommands(args.user, args.envpass)

--- a/onyx/cli.py
+++ b/onyx/cli.py
@@ -444,7 +444,7 @@ class FilterCommands(ClientRequired):
         if scope:
             scope = utils.flatten_list_of_lists(scope)
 
-        results = utils.iterate(
+        results = utils.iterate_records(
             self.client.filter(project, fields, exclude=exclude, scope=scope)
         )
 

--- a/onyx/cli.py
+++ b/onyx/cli.py
@@ -78,7 +78,7 @@ class ConfigCommands(ConfigRequired):
         config_dir = config_dir.replace("~", os.path.expanduser("~"))
 
         if os.path.isfile(config_dir):
-            raise FileExistsError("Provided path to a file, not a directory")
+            raise FileExistsError("Provided path to a file, not a directory.")
 
         if not os.path.isdir(config_dir):
             os.mkdir(config_dir)

--- a/onyx/config.py
+++ b/onyx/config.py
@@ -37,13 +37,13 @@ class OnyxConfig:
         if dir_path:
             # Check config dir path is a directory
             if not os.path.isdir(dir_path):
-                raise FileNotFoundError(f"'{dir_path}' does not exist")
+                raise FileNotFoundError(f"'{dir_path}' does not exist.")
 
             # Check config file path is a file
             file_path = os.path.join(dir_path, settings.CONFIG_FILE_NAME)
             if not os.path.isfile(file_path):
                 raise FileNotFoundError(
-                    f"Config file does not exist in directory '{dir_path}'"
+                    f"Config file does not exist in directory '{dir_path}'."
                 )
         else:
             # Find the config directory
@@ -52,14 +52,14 @@ class OnyxConfig:
             # Check config dir path is a directory
             if not os.path.isdir(dir_path):
                 raise FileNotFoundError(
-                    f"'{settings.CONFIG_DIR_ENV_VAR}' points to a directory that does not exist"
+                    f"'{settings.CONFIG_DIR_ENV_VAR}' points to a directory that does not exist."
                 )
 
             # Check config file path is a file
             file_path = os.path.join(dir_path, settings.CONFIG_FILE_NAME)
             if not os.path.isfile(file_path):
                 raise FileNotFoundError(
-                    f"Config file does not exist in directory '{dir_path}'"
+                    f"Config file does not exist in directory '{dir_path}'."
                 )
 
         return dir_path, file_path
@@ -70,13 +70,13 @@ class OnyxConfig:
         """
         for field in settings.CONFIG_FIELDS:
             if field not in config:
-                raise KeyError(f"'{field}' key is missing from the config file")
+                raise KeyError(f"'{field}' key is missing from the config file.")
 
         for user, ufields in config["users"].items():
             for field in settings.USER_FIELDS:
                 if field not in ufields:
                     raise KeyError(
-                        f"'{field}' key is missing from user '{user}' in the config file"
+                        f"'{field}' key is missing from user '{user}' in the config file."
                     )
 
     def write_token(self, username, token, expiry):
@@ -146,7 +146,7 @@ class OnyxConfig:
 
         if username not in self.users:
             raise KeyError(
-                f"User '{username}' is not in the config. Add them using the add-user command"
+                f"User '{username}' is not in the config. Add them using the add-user command."
             )
 
         self.default_user = username

--- a/onyx/utils.py
+++ b/onyx/utils.py
@@ -175,7 +175,7 @@ def execute_uploads(uploads):
         print(f"Failures: {failures}")
 
 
-def iterate(responses):
+def iterate_records(responses):
     for response in responses:
         raise_for_status(response)
 

--- a/onyx/utils.py
+++ b/onyx/utils.py
@@ -30,7 +30,7 @@ def construct_unique_fields_dict(arg_fields):
     if arg_fields is not None:
         for f, v in arg_fields:
             if f in fields:
-                raise KeyError(f"Field '{f}' was provided more than once")
+                raise KeyError(f"Field '{f}' was provided more than once.")
             else:
                 fields[f] = v
     return fields
@@ -122,7 +122,7 @@ def session_required(method):
 
         def wrapped_generator_method(obj, *args, **kwargs):
             if not hasattr(obj, "token"):
-                raise Exception("The client has no token to log in with")
+                raise Exception("The client has no token to log in with.")
             try:
                 # Run the method and yield the output
                 output = yield from method(obj, *args, **kwargs)
@@ -138,7 +138,7 @@ def session_required(method):
 
         def wrapped_method(obj, *args, **kwargs):
             if not hasattr(obj, "token"):
-                raise Exception("The client has no token to log in with")
+                raise Exception("The client has no token to log in with.")
             try:
                 # Run the method and get the output
                 output = method(obj, *args, **kwargs)

--- a/onyx/utils.py
+++ b/onyx/utils.py
@@ -57,7 +57,7 @@ def print_response(response, pretty_print=True, status_only=False):
         indent = None
     status_code = f"<[{response.status_code}] {response.reason}>"
     try:
-        if status_only:
+        if status_only and response.ok:
             formatted_response = str(status_code)
         else:
             formatted_response = (

--- a/onyx/utils.py
+++ b/onyx/utils.py
@@ -36,11 +36,11 @@ def construct_unique_fields_dict(arg_fields):
     return fields
 
 
-def construct_scope_list(arg_fields):
+def flatten_list_of_lists(arg_fields):
     """
-    Takes a list of list of scopes: `[[scope, scope, ...], [scope, scope, ...], ...]`
+    Takes a list of lists: `[[val1, val2, ...], [val3, val4, ...], ...]`
 
-    Returns a list of scopes: `[scope, scope, scope, ...]`
+    Returns a single list: `[val1, val2, ..., val3, val4, ...]`
     """
     return [s for scopes in arg_fields for s in scopes]
 


### PR DESCRIPTION
- Reworked OnyxClient so that `continue_session` function has been merged into `__init__` meaning, all OnyxClient methods (aside from `register`, which is now a `classmethod`) require login which is done at point of object instantiation.
- OnyxClient as a context manager now uses the actual `requests.Session` object for requests, meaning the same underlying TCP connection is reused within context manager, resulting in a speedup of the client.
- The OnyxSession has been ditched because it wasn't providing anything of value anymore.
- Added `--exclude` flag to give the user control of removing fields from the server's serialized response.
- Updated README.